### PR TITLE
Improved javadoc, code cleanup and improving the Beacon Builder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ IBeaconScanner.getInstance().setCallback(this);
 
 
 ```
-final Beacon beacon = new Beacon.Builder()
+final Beacon beacon = Beacon.newBuilder()
     .setUUID("84be19d4-797d-11e5-8bcf-feff819cdc9f")
     .setMajor(1)
     .setMinor(2)

--- a/app/src/main/java/mobi/inthepocket/android/beacons/app/MainActivity.java
+++ b/app/src/main/java/mobi/inthepocket/android/beacons/app/MainActivity.java
@@ -47,7 +47,7 @@ public class MainActivity extends AppCompatActivity implements IBeaconScanner.Ca
 
         IBeaconScanner.getInstance().setCallback(this);
 
-        // add input filters on {@link EditText}'s.
+        // add input filters on {@link EditText}s.
         this.editTextMajor.setFilters(new InputFilter[]{new InputFilterMinMax("1", "65535")});
         this.editTextMinor.setFilters(new InputFilter[]{new InputFilterMinMax("1", "65535")});
 
@@ -75,7 +75,7 @@ public class MainActivity extends AppCompatActivity implements IBeaconScanner.Ca
     {
         if (this.isValid())
         {
-            IBeaconScanner.getInstance().startMonitoring(new Beacon.Builder()
+            IBeaconScanner.getInstance().startMonitoring(Beacon.newBuilder()
                     .setUUID(this.editTextUuid.getText().toString())
                     .setMajor(Integer.valueOf(this.editTextMajor.getText().toString()))
                     .setMinor(Integer.valueOf(this.editTextMinor.getText().toString()))

--- a/app/src/main/java/mobi/inthepocket/android/beacons/app/utils/UUIDUtils.java
+++ b/app/src/main/java/mobi/inthepocket/android/beacons/app/utils/UUIDUtils.java
@@ -15,7 +15,7 @@ public final class UUIDUtils
     /**
      *
      * @param uuid
-     * @return true if {@param uuid} matches the UUID pattern
+     * @return true if {@code uuid} matches the UUID pattern
      */
     public static boolean isValidUUID(final String uuid)
     {

--- a/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/Beacon.java
+++ b/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/Beacon.java
@@ -110,7 +110,7 @@ public final class Beacon implements BeaconInterface, Parcelable
         @Override
         public Beacon createFromParcel(final Parcel in)
         {
-            return new Beacon.Builder()
+            return Beacon.newBuilder()
                     .setUUID(in.readString())
                     .setMajor(in.readInt())
                     .setMinor(in.readInt())
@@ -140,15 +140,30 @@ public final class Beacon implements BeaconInterface, Parcelable
 
     //endregion
 
+    //region Properties
+
+    /**
+     * @return a new {@link Builder} to create a {@link Beacon}
+     */
+    public static Builder newBuilder()
+    {
+        return new Builder();
+    }
+
+    //endregion
+
     //region Builder
 
-    public static class Builder
+    /**
+     * A Builder class to create a {@link Beacon} and validate the {@link #uuid}, {@link #major} and {@link #minor}.
+     */
+    public static final class Builder
     {
         private UUID uuid;
         private int major;
         private int minor;
 
-        public Builder()
+        private Builder()
         {
         }
 

--- a/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/IBeaconScanner.java
+++ b/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/IBeaconScanner.java
@@ -1,7 +1,7 @@
 package mobi.inthepocket.android.beacons.ibeaconscanner;
 
 /**
- * Created by eliaslecomte on 23/09/2016.
+ *  Initialization and configuration entry point for iBeacon Scanner Android.
  */
 
 import android.Manifest;
@@ -31,8 +31,6 @@ import mobi.inthepocket.android.beacons.ibeaconscanner.utils.ScanFilterUtils;
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public final class IBeaconScanner implements TimeoutHandler.TimeoutCallback<Object>
 {
-    private static final String TAG = IBeaconScanner.class.getSimpleName();
-
     private static IBeaconScanner instance;
 
     private final Context context;
@@ -43,21 +41,6 @@ public final class IBeaconScanner implements TimeoutHandler.TimeoutCallback<Obje
     private final AddBeaconsHandler addBeaconsHandler;
     private final Object timeoutObject;
     private final Set<Beacon> beacons;
-
-    public static IBeaconScanner getInstance()
-    {
-        if (instance == null)
-        {
-            throw new IllegalStateException("You need to initialize IBeaconScanner first in your Application class or in your Service onCreate");
-        }
-
-        return instance;
-    }
-
-    public static void initialize(@NonNull final Initializer initializer)
-    {
-        instance = new IBeaconScanner(initializer);
-    }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private IBeaconScanner(@NonNull final Initializer initializer)
@@ -74,6 +57,31 @@ public final class IBeaconScanner implements TimeoutHandler.TimeoutCallback<Obje
         this.beacons = new HashSet<>();
     }
 
+    public static IBeaconScanner getInstance()
+    {
+        if (instance == null)
+        {
+            throw new IllegalStateException("You need to initialize IBeaconScanner first in your Application class or in your Service onCreate");
+        }
+
+        return instance;
+    }
+
+    /**
+     * Initialize {@link IBeaconScanner} with {@code initializer}.
+     *
+     * @param initializer You pass a {@link Context} object and can modify settings like the exit timeout ({@link Initializer#setExitTimeoutInMillis(long)})
+     */
+    public static void initialize(@NonNull final Initializer initializer)
+    {
+        instance = new IBeaconScanner(initializer);
+    }
+
+    /**
+     * Start monitoring {@code beacon} and all previously added {@link Beacon}s.
+     *
+     * @param beacon to start monitoring
+     */
     @RequiresPermission(Manifest.permission.BLUETOOTH_ADMIN)
     public void startMonitoring(@NonNull final Beacon beacon)
     {
@@ -81,6 +89,12 @@ public final class IBeaconScanner implements TimeoutHandler.TimeoutCallback<Obje
         this.addBeaconsHandler.passItem(this.timeoutObject);
     }
 
+    /**
+     * Stop monitoring for {@code beacon}. Keep monitoring for other {@link Beacon}s that were added with
+     * {@link #startMonitoring(Beacon)}.
+     *
+     * @param beacon to stop monitoring
+     */
     @RequiresPermission(Manifest.permission.BLUETOOTH_ADMIN)
     public void stopMonitoring(@NonNull final Beacon beacon)
     {
@@ -88,12 +102,18 @@ public final class IBeaconScanner implements TimeoutHandler.TimeoutCallback<Obje
         this.addBeaconsHandler.passItem(this.timeoutObject);
     }
 
+    /**
+     * Starts monitoring for previously added {@link Beacon}s.
+     */
     @RequiresPermission(Manifest.permission.BLUETOOTH_ADMIN)
     public void start()
     {
         this.addBeaconsHandler.passItem(this.timeoutObject);
     }
 
+    /**
+     * Stops monitoring and removes all monitored {@link Beacon}s.
+     */
     @RequiresPermission(Manifest.permission.BLUETOOTH_ADMIN)
     public void stop()
     {
@@ -103,6 +123,10 @@ public final class IBeaconScanner implements TimeoutHandler.TimeoutCallback<Obje
 
     //region Properties
 
+    /**
+     * @param context to create {@link IBeaconScanner} with
+     * @return new {@link Initializer}
+     */
     public static Initializer newInitializer(@NonNull final Context context)
     {
         return new Initializer(context);
@@ -227,7 +251,7 @@ public final class IBeaconScanner implements TimeoutHandler.TimeoutCallback<Obje
         }
 
         /**
-         * After {@param exitTimeoutInMillis}, when a beacon is not seen, the exit callback:
+         * After {@code exitTimeoutInMillis}, when a beacon is not seen, the exit callback:
          * {@link Callback#didExitBeacon(Beacon)} is called.
          *
          * @param exitTimeoutInMillis
@@ -241,8 +265,8 @@ public final class IBeaconScanner implements TimeoutHandler.TimeoutCallback<Obje
         }
 
         /**
-         * Everytime you start or stop monitoring a {@link Beacon}, we wait {@param addBeaconTimeoutInMillis} before
-         * changes are applied. If you add several {@link Beacon}'s, this will evade that scans are stop-started everytime.
+         * Everytime you start or stop monitoring a {@link Beacon}, we wait {@code addBeaconTimeoutInMillis} before
+         * changes are applied. If you add several {@link Beacon}s, this will evade that scans are stop-started everytime.
          * Starting from Android N, if you start a scan more than 5 times in 30 seconds, scans are blocked.
          *
          * @param addBeaconTimeoutInMillis
@@ -280,12 +304,30 @@ public final class IBeaconScanner implements TimeoutHandler.TimeoutCallback<Obje
 
     //region Callback
 
+    /**
+     * Callback object that notifies of {@link Beacon} enter, exits or moinotiring fails.
+     */
     public interface Callback
     {
+        /**
+         * Device is inside the range of {@code beacon}.
+         *
+         * @param beacon
+         */
         void didEnterBeacon(Beacon beacon);
 
+        /**
+         * Device is outside the range of {@code beacon}.
+         *
+         * @param beacon
+         */
         void didExitBeacon(Beacon beacon);
 
+        /**
+         * Monitoring could not start due to {@code error}.
+         *
+         * @param error that happened
+         */
         void monitoringDidFail(Error error);
     }
 

--- a/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/ScannerScanCallback.java
+++ b/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/ScannerScanCallback.java
@@ -26,7 +26,7 @@ import mobi.inthepocket.android.beacons.ibeaconscanner.utils.ConversionUtils;
  * Created by eliaslecomte on 28/09/2016.
  *
  * Class is responseable for:
- * - Reading beacon information from {@link ScanResult}'s that are triggered by the {@link android.bluetooth.le.BluetoothLeScanner}.
+ * - Reading beacon information from {@link ScanResult}s that are triggered by the {@link android.bluetooth.le.BluetoothLeScanner}.
  * - Bookkeeping of beacon triggers so it can determine weather a beacon entered or exited a {@link Beacon}.
  * - Calling {@link IBeaconScanner.Callback#didEnterBeacon(Beacon)} and
  *  {@link IBeaconScanner.Callback#didExitBeacon(Beacon)}.
@@ -104,7 +104,7 @@ public class ScannerScanCallback extends ScanCallback implements TimeoutHandler.
                 //final int minor = (scanRecord[startByte + 22] & 0xff) * 0x100 + (scanRecord[startByte + 23] & 0xff);
                 final int minor = ConversionUtils.byteArrayToInteger(Arrays.copyOfRange(scanRecord, startByte + 22, startByte + 24));
 
-                final Beacon beacon = new Beacon.Builder()
+                final Beacon beacon = Beacon.newBuilder()
                         .setUUID(uuid)
                         .setMajor(major)
                         .setMinor(minor)
@@ -164,7 +164,7 @@ public class ScannerScanCallback extends ScanCallback implements TimeoutHandler.
     }
 
     /**
-     * Restarts countdown timers for entered {@link Beacon}'s that were not yet exited.
+     * Restarts countdown timers for entered {@link Beacon}s that were not yet exited.
      */
     private void resumeExits()
     {
@@ -187,7 +187,8 @@ public class ScannerScanCallback extends ScanCallback implements TimeoutHandler.
 
             for (final BeaconSeen beaconSeen : beaconSeens)
             {
-                final Beacon beacon = new Beacon.Builder().setUUID(beaconSeen.getUuid())
+                final Beacon beacon = Beacon.newBuilder()
+                        .setUUID(beaconSeen.getUuid())
                         .setMajor(beaconSeen.getMajor())
                         .setMinor(beaconSeen.getMinor())
                         .build();

--- a/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/database/DatabaseUtils.java
+++ b/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/database/DatabaseUtils.java
@@ -32,7 +32,7 @@ public final class DatabaseUtils
     {
         try
         {
-            if (validateCursor(cursor, columnName))
+            if (validateCursor(cursor))
             {
                 String str = cursor.getString(getIndex(cursor, columnName, projectionKey));
 
@@ -63,7 +63,7 @@ public final class DatabaseUtils
     {
         try
         {
-            if (validateCursor(cursor, columnName))
+            if (validateCursor(cursor))
             {
                 return cursor.getInt(getIndex(cursor, columnName, projectionKey));
             }
@@ -115,10 +115,9 @@ public final class DatabaseUtils
 
     /**
      * @param cursor
-     * @param columnName
      * @return true if the cursor is not null, not closed, not after the last entry, not before the first entry.
      */
-    private static boolean validateCursor(final Cursor cursor, final String columnName)
+    private static boolean validateCursor(final Cursor cursor)
     {
         return cursor != null && !cursor.isClosed() && !cursor.isAfterLast() && !cursor.isBeforeFirst();
     }

--- a/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/utils/ConversionUtils.java
+++ b/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/utils/ConversionUtils.java
@@ -74,8 +74,8 @@ public final class ConversionUtils
     public static byte[] integerToByteArray(final int value)
     {
         final byte[] result = new byte[2];
-        result[0] = (byte) (value / 256); // Byte.parseByte(String.valueOf(value / 256), 16);
-        result[1] = (byte) (value % 256); // Byte.parseByte(String.valueOf(value % 256), 16);
+        result[0] = (byte) (value / 256);
+        result[1] = (byte) (value % 256);
 
         return result;
     }

--- a/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/utils/LocationUtils.java
+++ b/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/utils/LocationUtils.java
@@ -23,7 +23,7 @@ public final class LocationUtils
      *
      * @param context to determine with if location is on
      * @return true if location is turned on or the sdk is below Android M.
-     * @throws InvalidParameterException if {@param context} is null
+     * @throws InvalidParameterException if {@code context} is null
      */
     public static boolean isLocationOn(final Context context)
     {

--- a/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/utils/PermissionUtils.java
+++ b/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/utils/PermissionUtils.java
@@ -28,7 +28,7 @@ public final class PermissionUtils
      *
      * @param context to determine with if the permission is granted
      * @return true if you have any location permission or the sdk is below Android M.
-     * @throws InvalidParameterException if {@param context} is null
+     * @throws InvalidParameterException if {@code context} is null
      */
     public static boolean isLocationGranted(@NonNull final Context context) throws InvalidParameterException
     {

--- a/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/utils/ScanFilterUtils.java
+++ b/ibeaconscanner/src/main/java/mobi/inthepocket/android/beacons/ibeaconscanner/utils/ScanFilterUtils.java
@@ -10,7 +10,7 @@ import mobi.inthepocket.android.beacons.ibeaconscanner.interfaces.BeaconInterfac
 /**
  * Created by eliaslecomte on 23/09/2016.
  *
- * Utils class to create {@link ScanFilter}'s for a {@link BeaconInterface}.
+ * Utils class to create {@link ScanFilter}s for a {@link BeaconInterface}.
  */
 
 public final class ScanFilterUtils

--- a/ibeaconscanner/src/test/java/mobi/inthepocket/android/beacons/ibeaconscanner/BeaconTest.java
+++ b/ibeaconscanner/src/test/java/mobi/inthepocket/android/beacons/ibeaconscanner/BeaconTest.java
@@ -31,7 +31,7 @@ public class BeaconTest
 
         while (major <= 65535)
         {
-            final Beacon beacon = new Beacon.Builder()
+            final Beacon beacon = Beacon.newBuilder()
                     .setUUID(EXAMPLE_BEACON_1_UUID)
                     .setMajor(major)
                     .setMinor(EXAMPLE_BEACON_1_MINOR)
@@ -50,7 +50,7 @@ public class BeaconTest
 
         while (minor <= 65535)
         {
-            final Beacon beacon = new Beacon.Builder()
+            final Beacon beacon = Beacon.newBuilder()
                     .setUUID(EXAMPLE_BEACON_1_UUID)
                     .setMajor(EXAMPLE_BEACON_1_MAJOR)
                     .setMinor(minor)
@@ -67,7 +67,7 @@ public class BeaconTest
     {
         final UUID uuid = UUID.randomUUID();
 
-        final Beacon beacon = new Beacon.Builder()
+        final Beacon beacon = Beacon.newBuilder()
                 .setUUID(uuid)
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)
@@ -79,7 +79,7 @@ public class BeaconTest
     @Test(expected = IllegalUUIDException.class)
     public void testWithoutUUID()
     {
-        final Beacon beacon = new Beacon.Builder()
+        final Beacon beacon = Beacon.newBuilder()
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)
                 .build();
@@ -88,8 +88,8 @@ public class BeaconTest
     @Test(expected = IllegalArgumentException.class)
     public void testWrongUUIDString()
     {
-        final Beacon beacon = new Beacon.Builder()
-                .setUUID(new String())
+        final Beacon beacon = Beacon.newBuilder()
+                .setUUID("")
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)
                 .build();
@@ -98,7 +98,7 @@ public class BeaconTest
     @Test(expected = IllegalMajorException.class)
     public void testNegativeMajor() throws Exception
     {
-        final Beacon beacon = new Beacon.Builder()
+        final Beacon beacon = Beacon.newBuilder()
                 .setUUID(EXAMPLE_BEACON_1_UUID)
                 .setMajor(-1)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)
@@ -108,7 +108,7 @@ public class BeaconTest
     @Test(expected = IllegalMinorException.class)
     public void testNegativeMinor() throws Exception
     {
-        final Beacon beacon = new Beacon.Builder()
+        final Beacon beacon = Beacon.newBuilder()
                 .setUUID(EXAMPLE_BEACON_1_UUID)
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(-1)
@@ -118,7 +118,7 @@ public class BeaconTest
     @Test(expected = IllegalMajorException.class)
     public void testToHighMajor() throws Exception
     {
-        final Beacon beacon = new Beacon.Builder()
+        final Beacon beacon = Beacon.newBuilder()
                 .setUUID(EXAMPLE_BEACON_1_UUID)
                 .setMajor(MAJOR_MINOR_MAX_VALUE + 1)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)
@@ -128,7 +128,7 @@ public class BeaconTest
     @Test(expected = IllegalMinorException.class)
     public void testToHighMinor() throws Exception
     {
-        final Beacon beacon = new Beacon.Builder()
+        final Beacon beacon = Beacon.newBuilder()
                 .setUUID(EXAMPLE_BEACON_1_UUID)
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(MAJOR_MINOR_MAX_VALUE + 1)
@@ -138,13 +138,13 @@ public class BeaconTest
     @Test
     public void testEqualBeacons()
     {
-        final Beacon beacon1 = new Beacon.Builder()
+        final Beacon beacon1 = Beacon.newBuilder()
                 .setUUID(EXAMPLE_BEACON_1_UUID)
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)
                 .build();
 
-        final Beacon beacon2 = new Beacon.Builder()
+        final Beacon beacon2 = Beacon.newBuilder()
                 .setUUID(EXAMPLE_BEACON_1_UUID)
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)
@@ -156,13 +156,13 @@ public class BeaconTest
     @Test
     public void testNotEqualBeaconsByUUID()
     {
-        final Beacon beacon1 = new Beacon.Builder()
+        final Beacon beacon1 = Beacon.newBuilder()
                 .setUUID(EXAMPLE_BEACON_1_UUID)
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)
                 .build();
 
-        final Beacon beacon2 = new Beacon.Builder()
+        final Beacon beacon2 = Beacon.newBuilder()
                 .setUUID(UUID.randomUUID())
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)
@@ -174,13 +174,13 @@ public class BeaconTest
     @Test
     public void testNotEqualBeaconsByMajor()
     {
-        final Beacon beacon1 = new Beacon.Builder()
+        final Beacon beacon1 = Beacon.newBuilder()
                 .setUUID(EXAMPLE_BEACON_1_UUID)
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)
                 .build();
 
-        final Beacon beacon2 = new Beacon.Builder()
+        final Beacon beacon2 = Beacon.newBuilder()
                 .setUUID(EXAMPLE_BEACON_1_UUID)
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(EXAMPLE_BEACON_1_MINOR + 1)

--- a/ibeaconscanner/src/test/java/mobi/inthepocket/android/beacons/ibeaconscanner/ConversionUtilsTest.java
+++ b/ibeaconscanner/src/test/java/mobi/inthepocket/android/beacons/ibeaconscanner/ConversionUtilsTest.java
@@ -37,7 +37,7 @@ public class ConversionUtilsTest
     @Test
     public void testExampleBeacon1ScanFilter()
     {
-        final Beacon beacon = new Beacon.Builder()
+        final Beacon beacon = Beacon.newBuilder()
                 .setUUID(EXAMPLE_BEACON_1_UUID)
                 .setMajor(EXAMPLE_BEACON_1_MAJOR)
                 .setMinor(EXAMPLE_BEACON_1_MINOR)


### PR DESCRIPTION
* Remove unused method parameter.

* Change how to use the Beacon Builder.

* Remove wrong comment.

* Remove unused comment.

* Move the constructor to the top.

* Add javadoc for IBeaconScanner.

* Remove ' for plurals.

* Use {@code x} instead of {@param x}.

* Add javadoc for IBeaconScanner.Callback.